### PR TITLE
Update TIP-13.md

### DIFF
--- a/TIPs/TIP-13.md
+++ b/TIPs/TIP-13.md
@@ -33,7 +33,6 @@ Proposed format:
 * After Sign-up phase is over, each Thales Royale starts with total of 6 rounds with each round lasting 24h.
 * Each round has a 8h position phase and a 16h resolution phase.
 * Buy-in is to be set to 30 sUSD.
-* Each round has a 8h position phase and a 16h resolution phase.
 * The price of ETH at the end of the 16h Resolution Phase is the result used for round resolution of the finished round and, at the same time, the starting Strike Price of the next round.
 * Within the 8h Positioning Phase, players have to signal if the ETH price will be higher or lower at the end of the current round than current round Strike Price. Players can change their position as many times as they want during the positioning phase.
 * If there is only a single person "alive" after a certain round, he is declared winner.


### PR DESCRIPTION
Removed duplicity of "* Each round has a 8h position phase and a 16h resolution phase."