### PR TITLE
Adding SafeBox insurance for AMM LPs

### DIFF
--- a/TIPs/TIP-133.md
+++ b/TIPs/TIP-133.md
@@ -1,6 +1,6 @@
 | id | Title | Status | Author | Description | Discussions to | Created |
 | ----------- | ----------- | ----------- | ----------- | ----------- | ----------- | ----------- |
-| TIP-133 | Allow keeper bots to directly update odds on Overtime| Draft | Danijel (@danthales)| Allow keeper bots to directly update odds on Overtime| https://discord.gg/thales | 2023-03-16
+| TIP-133 | Allow keeper bots to directly update odds on Overtime| Draft | Danijel (@danthales) BigPenny (@RealBigPenny)| Allow keeper bots to directly update odds on Overtime| https://discord.gg/thales | 2023-03-16
 
 
 ## Simple Summary
@@ -9,7 +9,7 @@ This TIP proposes to allow whitelisted keeper bots to update odds on Overtime
 
 ## Abstract
 
-Due to delays and cost inefficiencies of using Chainlink Node infrastructure, I am proposing to allow whitelisted keeper addresses to perform odds updates
+Due to delays and cost inefficiencies of using Chainlink Node infrastructure, I am proposing to allow whitelisted keeper addresses to perform odds updates. SafeBox funds can be used to cover losses caused by odds corruptions.
   
 ## Motivation
 
@@ -26,7 +26,7 @@ By using centralized bots for managing odds I estimate we can:
 
 Reducing the gas costs and allowing us more flexibility on how we perform and batch odds updates allows for easier adding of more chains. As it stands now, its difficult to support adding more chains with all the costs and risk overhead. It will also help with considering the costs and risks of adding new sports. Expediting odds updates might also allow us to consider live markets.
 
-In terms of centralization risks, I am only proposing using keeper bots directly for odds, and still using CL nodes for market creation and resolution. Centralizing the odds updates has no risks for end users, as they always see which odds they are getting when trading. However, it does include an additional risk for liquidity providers if those bots are compromised, but should an attack take place, pDAO can cancel the affected markets thus not allowing attackers to take profit. Circuit breakers which we have built in mitigate this attack vector to some extent. Besides adheering to cyber security measures to protect the whitelisted wallets, Council could consider introducing an insurance fund for Liquidity Providers, or using the SafeBox for that purpose. However, at this point the proposed solution is likely a good compromise for Liquidity Providers as it ensures sharper odds and mitigates frontrunning surface. 
+In terms of centralization risks, I am only proposing using keeper bots directly for odds, and still using CL nodes for market creation and resolution. Centralizing the odds updates has no risks for end users, as they always see which odds they are getting when trading. However, it does include an additional risk for liquidity providers if those bots are compromised, but should an attack take place, pDAO can cancel the affected markets thus not allowing attackers to take profit. Circuit breakers which we have built in mitigate this attack vector to some extent. At this point the proposed solution is likely a good compromise for Liquidity Providers as it ensures sharper odds and mitigates frontrunning surface. Since odds centralization is to a limited extend deviating from the ETH decentralization maxim, it is in best interest of the Thales protocol to try and insure AMM LPs against the (unlikely) risks involved. 
 
 I am a big proponent of decentralized oracles, and will still be on the lookout and how to get back to using more decentralized solutions once better tooling is available. With regards to gas costs, EIP-4844 should introduce significant L2 gas costs reduction (planned for Q3 2023), so we could revisit this decision once its live.  
 
@@ -36,6 +36,8 @@ Additionally, tools such as Chainlink functions could provide an alternative sol
 
 Allow whitelisted addresses to directly update odds on Overtime. 
 All existing Chainlink node infrastructure will remain operational and can still be used as backup or complementary utility for permissionless odds updates.
+
+If AMM LPs incur losses causes by odds corruptions, SafeBox shall cover such losses in full, sufficient funding of SafeBox presumed. pDAO holds discretion over SafeBox payouts for the aforementioned purpose. Thales Council retains the right to veto pDAO decisions both in favor and against SafeBox payouts via TIP proposal and subsequent approval. pDAO shall give Thales Council prior notice and reasonable time to exercise its veto rights.
 
 ## Implementation
 


### PR DESCRIPTION
AMM LP losses caused by odds corruption are covered by SafeBox.