### PR TITLE
Create TIP-198

### DIFF
--- a/TIPs/TIP-198.md
+++ b/TIPs/TIP-198.md
@@ -1,0 +1,51 @@
+| id    | Title | Status      | Author  | Description | Discussions to | Created    |
+| ----- | ----- | ----------- | ------- | ----------- | -------------- | ---------- |
+| TIP-198 | Bridge Thales using CCIP | Draft | Kiril (Thales) | Use CCIP to bridge THALES across all supported networks | [discordlink ](https://discord.gg/thales)   | 2024-03-20 |
+
+
+## Simple Summary
+
+
+Use Chainlink Cross-Chain Interoperability Protocol (CCIP) to bridge THALES token across all supported networks.
+
+
+## Abstract
+
+Chainlink CCIP has proven as a reliable protocol which can be used as a secure bridge along current bridging.  
+THALES token holders may benefit from lower fees without compensating security.
+
+
+## Motivation
+
+Currently Celer bridge, native OP bridge and other bridge aggregators are used for bridging THALES token.
+
+After successful implementaion of [TIP-181](https://github.com/thales-markets/thales-improvement-proposals/blob/main/TIPs/TIP-181.md), this TIP proposes the use of Chainlink CCIP to enable THALES token holders to bridge accross all supported network. The idea is to provide multiple secure bridging options for THALES token holders. Chainlink CCIP operates at the highest level of cross-chain security by taking a defense-in-depth approach, where multiple decentralized oracle networks and an independent Risk Management Network secure each transaction.
+
+The implementation details are laid in the specification
+
+## Specification
+
+New *ThalesBridgePool* contracts are deployed on every supported network. Each *ThalesBridgePool* contract is pre-loaded with THALES tokens.  
+A user initiates bridging of THALES tokens from origin network by depositing *X* amount of THALES to the origin *ThalesBridgePool* and triggering a CCIP message to be sent to a destination *ThalesBridgePool* on destination network. Upon successful CCIP messaging, the destination *ThalesBridgePool* transfers *X* amount of THALES to the user address on the destination network.  
+Note: the destination address can differ from the user address and can be arbitrary chosen.
+
+For example, if user decides to bridge from Optimism to Arbitrum network an amount of 100 THALES:
+
+1. The user approves *ThalesBridgePool* on Optimism.
+2. The user triggers bridging function that deposits 100 THALES to the *ThalesBridgePool* on Optimism
+3. The Optimism *ThalesBridgePool* generates a CCIP message that is sent to Arbitrum *ThalesBridgePool*.
+4. The Arbitrum *ThalesBridgePool* receives the message and obtains a destination address.
+5. The Arbitrum *ThalesBridgePool* transfers 100 THALES to the destination address.
+
+## Test Cases
+
+- Bridge between OP Sepolia and Arbitrum Sepolia
+
+
+## Implementation
+
+- ThalesBridgePool contract - perform cross-chain messaging and holds pool of THALES tokens.
+
+## Copyright
+
+Copyright and related rights waived via CC0.

--- a/TIPs/TIP-198.md
+++ b/TIPs/TIP-198.md
@@ -26,25 +26,31 @@ The implementation details are laid in the specification
 ## Specification
 
 New *ThalesBridgePool* contracts are deployed on every supported network. Each *ThalesBridgePool* contract is pre-loaded with THALES tokens.  
-A user initiates bridging of THALES tokens from origin network by depositing *X* amount of THALES to the origin *ThalesBridgePool* and triggering a CCIP message to be sent to a destination *ThalesBridgePool* on destination network. Upon successful CCIP messaging, the destination *ThalesBridgePool* transfers *X* amount of THALES to the user address on the destination network.  
+A user initiates bridging of THALES tokens from origin network by depositing *X* amount of THALES to the origin *ThalesBridgePool* and triggering a CCIP message to be sent to a destination *ThalesBridgePool* on destination network. Upon successful CCIP messaging, the destination *ThalesBridgePool* transfers *(X - fees)* amount of THALES to the user address on the destination network.  
+In case of unsuccessful bridge operation, the funds are refunded to the user on the origin chain.  
 Note: the destination address can differ from the user address and can be arbitrary chosen.
 
-For example, if user decides to bridge from Optimism to Arbitrum network an amount of 100 THALES:
+For example, if user decides to bridge from Optimism to Arbitrum network an amount of 100 THALES with 0.5% fees:
 
 1. The user approves *ThalesBridgePool* on Optimism.
-2. The user triggers bridging function that deposits 100 THALES to the *ThalesBridgePool* on Optimism
-3. The Optimism *ThalesBridgePool* generates a CCIP message that is sent to Arbitrum *ThalesBridgePool*.
-4. The Arbitrum *ThalesBridgePool* receives the message and obtains a destination address.
-5. The Arbitrum *ThalesBridgePool* transfers 100 THALES to the destination address.
+2. The user triggers bridging function that deposits 100 THALES to the *ThalesBridgePool* on Optimism.
+3. Fee of 0.5% is applied and 0.5 THALES are stored ready to be burned.
+4. The Optimism *ThalesBridgePool* generates a CCIP message that is sent to Arbitrum *ThalesBridgePool*.
+5. The Arbitrum *ThalesBridgePool* receives the message and obtains a destination address.
+6. The Arbitrum *ThalesBridgePool* transfers 99.5 THALES to the destination address.
+
+If the transfer at the destination network fails (e.g. due to low THALES tokens on destination), the destination *ThalesBridgePool* sends back a CCIP message to the origin *ThalesBridgePool* to fully refund the user due to unsuccessful bridging.
 
 ## Test Cases
 
-- Bridge between OP Sepolia and Arbitrum Sepolia
+- Bridge between OP Sepolia and Arbitrum Sepolia.  
+- Bridge from OP Sepolia to Arbitrum Sepolia with unsuccessful execution on destination. Refund funds back to the user on origin chain
 
 
 ## Implementation
 
 - ThalesBridgePool contract - perform cross-chain messaging and holds pool of THALES tokens.
+- Fees - percentage fees for bridging.
 
 ## Copyright
 

--- a/TIPs/TIP-198.md
+++ b/TIPs/TIP-198.md
@@ -11,7 +11,7 @@ Use Chainlink Cross-Chain Interoperability Protocol (CCIP) to bridge THALES toke
 
 ## Abstract
 
-Chainlink CCIP has proven as a reliable protocol which can be used as a secure bridge along current bridging.  
+Chainlink CCIP has proven as a reliable protocol which can be used as a secure bridge along current bridging options.  
 THALES token holders may benefit from lower fees without compensating security.
 
 


### PR DESCRIPTION
Use Chainlink Cross-Chain Interoperability Protocol (CCIP) to bridge THALES token across all supported networks.